### PR TITLE
Add Line to Install Webview

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,2 @@
+go get github.com/webview/webview
 go build src/main.go


### PR DESCRIPTION
```
src/main.go:4:9: no required module provides package github.com/webview/webview: go.mod file not found in current directory or 
any parent directory; see 'go help modules'
```

If webview package is not installed then user will get the above error.
So, added ```go get github.com/webview/webview``` in ```./build.sh```